### PR TITLE
Fix #1

### DIFF
--- a/results.js
+++ b/results.js
@@ -10,4 +10,4 @@ function markresults() {
     }
 }
 
-window.addEventListener('load', setTimeout(markresults,1100));
+window.addEventListener('load', function(){ setTimeout(markresults,1100) });


### PR DESCRIPTION
I haven't tested this but it's almost guaranteed to work.

Ooh also this supports loads of browsers, whereas ECMA6 syntax, arrow functions, would be more concise but at the cost of browser support (for things like IE, which doesn't support this format of extension anyway...)

(Other syntax, for the record, is `() => setTimeout(...)`

And just in case GitHub didn't get it from the title, this issue fixes #1